### PR TITLE
Use Chokidar to watch files

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@ services:
       - REMOTE_CHROME_URL=http://chrome:9222
       - PORT=4000
       - WEBPACK_USE_POLLING=yup
+      - CHOKIDAR_USEPOLLING=1
     working_dir: /uswds-data
     command: yarn start
     ports:

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -4,6 +4,7 @@ const gulp = require('gulp');
 const sass = require('gulp-sass');
 const sourcemaps = require('gulp-sourcemaps');
 const webpack = require('webpack-stream');
+const chokidar = require('chokidar');
 
 const webpackConfig = require('./webpack.config');
 const staticServerApp = require('./config/static-server').app;
@@ -47,19 +48,26 @@ gulp.task('copy-uswds-assets', () => {
 
 gulp.task('watch', ['build'], _ => {
   const rebuildHugo = util.serializedTask('hugo');
+  const rebuildSass = util.serializedTask('sass');
 
   staticServerApp.listen(PORT, () => {
     console.log(`Static server listening on port ${PORT}.`);
   });
 
-  gulp.watch([
+  chokidar.watch([
     'config.toml',
     'content/**/*',
     'static/**/*',
     'layouts/**/*',
-  ], rebuildHugo);
+  ], {
+    ignoreInitial: true,
+  }).on('all', rebuildHugo);
 
-  gulp.watch('./sass/**/*.scss', ['sass']);
+  chokidar.watch([
+    './sass/**/*.scss',
+  ], {
+    ignoreInitial: true,
+  }).on('all', rebuildSass);
 
   // Note that because running webpack in watch mode causes it to
   // do an initial build, this means that we'll actually be running

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "axe-core": "^2.3.1",
     "chalk": "^2.1.0",
+    "chokidar": "^1.7.0",
     "chrome-launcher": "^0.6.0",
     "chrome-remote-interface": "^0.24.5",
     "express": "^4.15.4",


### PR DESCRIPTION
`gulp.watch()` doesn't seem to trigger on newly added/deleted files and directories, but Chokidar does, so we'll use it instead.
