### PR TITLE
Provide tabular alternatives for bar charts.

### DIFF
--- a/content/components/charts.md
+++ b/content/components/charts.md
@@ -14,8 +14,8 @@ Accessibility for vertical bar charts lorem ipsum dolor sit amet, consectetur ad
 See additional info about color in the overall [accessibility guidelines](design-principals/accessibility/).
 
 <h4 class="usa-chart-title">Uninsured Rate in Virginia, 2008–2015<sup>1</sup></h4>
-<div class="chart" style="height: 350px; width: 100%;"></div>
-<div class="usa-legend">
+<div id="vertical" class="chart" style="height: 350px; width: 100%;"></div>
+<div class="usa-legend" aria-hidden="true">
   <span class="usa-legend-box"></span>
     <span class="usa-legend-text">U.S. Government</span>
   <span class="usa-legend-box"></span>
@@ -24,9 +24,24 @@ See additional info about color in the overall [accessibility guidelines](design
 
 <h4 class="usa-chart-title">Uninsured Rate in Virginia, 2008–2015<sup>1</sup></h4>
 <div id="horizontal" class="chart" style="height: 350px; width: 100%;"></div>
-<div class="usa-legend">
+<div class="usa-legend" aria-hidden="true">
   <span class="usa-legend-box"></span>
     <span class="usa-legend-text">U.S. Government</span>
   <span class="usa-legend-box"></span>
     <span class="usa-legend-text">Virginia</span>
 </div>
+
+<h4 class="usa-chart-title">Tabular alternatives</h4>
+
+Due to the fact that bar charts are semantically similar to tabular data,
+the unpredictable support for accessible SVGs across browsers and
+screen readers, and the fact that many screen readers contain specialized
+controls for navigating tabular data easily, we recommend hiding
+graphical bar charts from screen readers and providing a tabular
+alternative for visually impaired users.
+
+A screen-reader only tabular version of the data is included with each
+SVG on this page to assist visually impaired users. Below is the
+tabular version made visible, for reference purposes.
+
+<div id="table"></div>

--- a/src/entry.js
+++ b/src/entry.js
@@ -4,7 +4,36 @@ var d3 = require('d3');
 var margin = { top: 30, right: 20, bottom: 30, left: 40 };
 var width = d3.select('.chart').node().offsetWidth - margin.right - margin.left;
 var height = 350 - margin.top - margin.bottom;
+var RATE_LABEL = 'Rate';
 
+function appendTable(d3selection, data) {
+    var table = d3selection.append('table');
+    var header = table.append('thead').append('tr');
+    var body = table.append('tbody');
+
+    header.selectAll('th')
+        .data(data.columns.map(function(d, i) {
+            return i === 0 ? d : d + ' ' + RATE_LABEL;
+        }))
+        .enter().append('th').text(function(d) { return d; });
+
+    body.selectAll('tr')
+        .data(data)
+        .enter().append('tr')
+        .selectAll('td')
+        .data(function(d) { return data.columns.map(function(label) { return d[label]; }); })
+        .enter().append('td').text(function(d) { return d; });
+
+    return table;
+}
+
+// tabular alternative (for screen readers)
+d3.csv('/data/uninsured_rate_in_virginia.csv', function(d, i, columns) {
+    for (var i = 1, n = columns.length; i < n; ++i) d[columns[i]] = +d[columns[i]];
+    return d;
+}, function(error, data) {
+    appendTable(d3.select('#table'), data);
+});
 
 // vertical bars
 d3.csv('/data/uninsured_rate_in_virginia.csv', function(d, i, columns) {
@@ -30,7 +59,9 @@ d3.csv('/data/uninsured_rate_in_virginia.csv', function(d, i, columns) {
   x1.domain(keys).rangeRound([0, x.bandwidth()]);
   y.domain([0, d3.max(data, function(d) { return d3.max(keys, function(key) { return d[key]; }); }) + 50]).n
 
-  var svg = d3.select('.chart').append('svg')
+  var container = d3.select('#vertical');
+  var svg = container.append('svg')
+              .attr('aria-hidden', 'true')
               .attr('height','100%')
               .attr('width','100%');
   var g = svg.append('g').attr('transform',
@@ -74,7 +105,9 @@ d3.csv('/data/uninsured_rate_in_virginia.csv', function(d, i, columns) {
       .attr('class', 'label')
       .attr('y', -20)
       .attr('x', -margin.left + 15)
-      .text('Rate')
+      .text(RATE_LABEL)
+
+  appendTable(container, data).attr('class', 'usa-sr-only');
 });
 
 // horizontal bars
@@ -102,7 +135,9 @@ d3.csv('/data/uninsured_rate_in_virginia.csv', function(d, i, columns) {
   y.domain(data.map(function(d) { return d.Year; }));
   y1.domain(keys).rangeRound([0, y.bandwidth()]);
 
-  var svg = d3.select('#horizontal').append('svg')
+  var container = d3.select('#horizontal');
+  var svg = container.append('svg')
+              .attr('aria-hidden', 'true')
               .attr('height','100%')
               .attr('width','100%');
   var g = svg.append('g').attr('transform',
@@ -147,5 +182,7 @@ d3.csv('/data/uninsured_rate_in_virginia.csv', function(d, i, columns) {
       .attr('class', 'label')
       .attr('y', -20)
       .attr('x', -margin.left + 20)
-      .text('Rate')
+      .text(RATE_LABEL)
+
+  appendTable(container, data).attr('class', 'usa-sr-only');
 });


### PR DESCRIPTION
This took a while for me to figure out.

At first I found a [CSS-Tricks article on accessible SVGs](https://css-tricks.com/accessible-svgs/) that had a whole bunch of information on how to create accessible SVGs. However, I had a *very* hard time actually making our bar charts accessible via screen readers in any meaningful way.

Aside from that, though, I also realized that our bar chart example is more complex than the one in the CSS-Tricks example: the latter is just a simple bar chart with one set of bars, which translates nicely to the semantic list structure it's marked-up with.  But because our chart breaks down each year into U.S. vs. Virgina rates, a table is more semantically accurate. (This semantic distinction is particularly important because many screen readers offer enhanced navigation controls for tables, e.g. allowing users to traverse down all the cells in a particular column.)

On top of that, even if marking up our SVGs properly for accessibility *did* work, it's still be a lot of hard-to-understand code, because we'd need to add an enormous amount of extra markup (such as 
`role="presentation"`) to much of the SVG in order to tell screen readers to ignore most of it.

As a result--and since we're auto-generating our SVGs on the client-side anyways--I simply opted to do what a [different article](https://simplyaccessible.com/article/7-solutions-svgs/) suggested, and put an `aria-hidden="true"` on the SVGs, and add a more semantically appropriate screen-reader alternative right next to them with `.usa-sr-only`.

For bar charts, since the screenreader alternative is a `<table>`, it might actually be appropriate (depending on the dataset) to make it visible to sighted users too, but in this case I kept them hidden from sighted users, just to showcase the concept.

That said, I do explain the concept at the end of the page, and include a visible version of the table so readers can see how it's structured:

> ![rates](https://user-images.githubusercontent.com/124687/30830808-454af5cc-a213-11e7-8dd1-3bd129d45c82.png)
